### PR TITLE
修改tsc编译错误

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare class ThinkSessionFile {
   constructor(options: object, ctx: object, cookieOptions?: object)
   autoUpdate(): void
   get(name: string): Promise<any>
-  set(name: string, value): Promise<any>
+  set(name: string, value: any): Promise<any>
   delete(): Promise<any>
   flush(): Promise<any>
   gc(): void


### PR DESCRIPTION
在使用think-cli new xxx typescript创建工程后，其中的tsconfig.json配置项有： "noImplicitAny": true,  使得用tsc编译的时候，会报
`
node_modules/think-session-file/index.d.ts:5:21 - error TS7006: Parameter 'value' implicitly has an 'any' type.

5   set(name: string, value): Promise<any>
`
现在将报错的参数加下any类型，解决这个问题。